### PR TITLE
docs: clarify component support and metadata extension precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ name, then appending the sidematter suffix:
 * For files with multiple extensions (e.g., `data.tar.gz`), only the final extension is
   dropped: `data.tar.gz` → `data.tar.meta.yml`.
 
-* Another example: `some-file.qa.md` → `some-file.qa.meta.yml`.
+* Another example: `some-file.form.md` → `some-file.form.meta.yml`.
 
 ### Metadata Schema
 


### PR DESCRIPTION
## Summary
This updates the Sidematter format description to make cross-implementation behavior more explicit and reusable.

### What changed
- Added a **Component Support** section defining metadata and assets as independent components.
- Clarified that implementations may support either component independently and should document supported components.
- Clarified path derivation with an explicit multi-extension example:
  - `some-file.qa.md` -> `some-file.qa.meta.yml`
- Clarified metadata extension policy:
  - canonical: `.meta.json`, `.meta.yml`
  - optional read compatibility: `.meta.yaml`
- Clarified metadata precedence order:
  1. `.meta.json`
  2. `.meta.yml`
  3. `.meta.yaml` (optional compatibility)
  4. optional frontmatter fallback

## Why
These clarifications reduce ambiguity for independent implementations and make the format easier to adopt consistently across different tools/languages.
